### PR TITLE
Edited C++ language alias

### DIFF
--- a/compilebot/sample-config.yml
+++ b/compilebot/sample-config.yml
@@ -22,7 +22,7 @@
       - test
   # Optional aliases for languages
   lang_aliases:
-    C++: C++11
+    C++: C++14
     Brainfuck: Brainf**k
     Lisp: Common Lisp
     Python3: Python 3


### PR DESCRIPTION
Ideone has moved to C++14 from C++11, so this should be updated in the sample-config.yml.