### PR TITLE
changed 'bitcontip' to 'bitcointip'

### DIFF
--- a/compilebot/sample-config.yml
+++ b/compilebot/sample-config.yml
@@ -15,7 +15,7 @@
     spam_phrases:
       - "rm "
       - "-rf"
-      - "bitcontip"
+      - "bitcointip"
     # Relax spam detection on some subreddits
     ignore:
       - compilebot


### PR DESCRIPTION
I'm assuming this was intended to be related to bitcoin, so I updated it to reflect. If `bitcontip` was intentional, please close this PR.